### PR TITLE
Updated with new element role 'AXLink' for Mac OS. Fixed issue when we g...

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -54,6 +54,12 @@ Also adds :code:`ui-inspector` script that allows you to inspect UI elements. Ju
 
 **Changelog:**
 
+
+UISoup 2.4.1 (released 4 Mar 2015)
+
+* Mac OS Additions: added new element role "AXLink".
+* Mac OS Additions: fixed issue when we getting fail on execution "get attribute "AXURL" of UI element" string.
+
 UISoup 2.4 (released 5 Feb 2015)
 
 * Mac OS Additions: fixed issue when we can't work with windows that have double quotes in name.

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ def package_env(file_name, strict=False):
 if __name__ == '__main__':
     setup(
         name='UISoup',
-        version='2.4',
+        version='2.4.1',
         description='Cross Platform GUI Test Automation tool.',
         long_description=package_env('README.rst'),
         author='Max Beloborodko',

--- a/uisoup/mac_soup/element.py
+++ b/uisoup/mac_soup/element.py
@@ -56,7 +56,8 @@ class MacElement(IElement):
         'AXApplication': u'app',
         'AXDocItem': u'doc',
         'AXHeading': u'tch',
-        'AXGenericElement': u'gen'
+        'AXGenericElement': u'gen',
+        'AXLink': u'lnk'
     }
 
     _mouse = MacMouse()

--- a/uisoup/utils/mac_utils.py
+++ b/uisoup/utils/mac_utils.py
@@ -313,7 +313,9 @@ class MacUtils(_Utils):
                    '  set visible to true',
                    '  set res to {}',
                    '  repeat with attr in attributes of %s' % obj_selector,
-                   '    set res to res & {{name of attr, value of attr}}',
+                   '    try',
+                   '      set res to res & {{name of attr, value of attr}}',
+                   '    end try',
                    '  end repeat',
                    '  return res',
                    'end tell']


### PR DESCRIPTION
...etting fail on execution "get attribute "AXURL" of UI element" string.